### PR TITLE
Fix preferred-message handling, add 'static bounds, and simplify envelope creation

### DIFF
--- a/actor/src/envelop.rs
+++ b/actor/src/envelop.rs
@@ -111,7 +111,7 @@ where
 #[async_trait]
 impl<S, M> EnvelopProxy<S> for EnvelopWithMessage<M>
 where
-    M: Message + Send,
+    M: Message + Send + 'static,
     S: Handler<M> + Send,
     M::Result: Send,
 {
@@ -120,6 +120,13 @@ where
         let result_channel = self.result_channel;
 
         if M::IS_PERFERRED {
+            if let Some(rc) = result_channel {
+                let handle = ReplyHandle::new(rc);
+                <S as Handler<M>>::handle_preferred(svc, message, ctx, handle).await;
+            } else {
+                let _ = <S as Handler<M>>::handle(svc, message, ctx).await;
+            }
+        } else {
             let res = <S as Handler<M>>::handle(svc, message, ctx).await;
 
             if let Some(rc) = result_channel {
@@ -127,9 +134,6 @@ where
                     log::warn!("Channel Closed");
                 }
             }
-        } else {
-            let handle = ReplyHandle::new(result_channel.unwrap());
-            <S as Handler<M>>::handle_preferred(svc, message, ctx, handle).await;
         }
     }
 }

--- a/actor/src/handler.rs
+++ b/actor/src/handler.rs
@@ -18,7 +18,10 @@ where
         message: M,
         ctx: &mut Context<Self, Self::Stream>,
         handle: ReplyHandle<M>,
-    ) {
+    ) where
+        M: Send + 'static,
+        M::Result: Send,
+    {
         let res = self.handle(message, ctx).await;
         let _ = handle.send(res);
     }

--- a/actor/src/service_address.rs
+++ b/actor/src/service_address.rs
@@ -50,11 +50,7 @@ where
     {
         let (sender, receiver) = oneshot::channel::<M::Result>();
 
-        let env = if M::IS_PERFERRED {
-            Envelope::new_with_result_channel(message, Some(sender))
-        } else {
-            Envelope::new_with_result_channel(message, Some(sender))
-        };
+        let env = Envelope::new_with_result_channel(message, Some(sender));
 
         self.sender
             .unbounded_send(env)


### PR DESCRIPTION
### Motivation

- Prevent a panic when sending preferred messages without a result channel and ensure preferred handlers are invoked correctly.
- Ensure message types meet lifetime requirements for asynchronous handling by adding `'static` bounds. 
- Simplify envelope construction in `ServiceAddress::call` to remove redundant branches.

### Description

- Update `EnvelopWithMessage` handling so that when `M::IS_PERFERRED` is true it uses a `ReplyHandle` only if a result channel is present, otherwise it calls the normal `handle` to discard results. 
- Add `+ 'static` bound to `M` in the `EnvelopProxy` impl for `EnvelopWithMessage` and add `M::Result: Send` constraints to the default `handle_preferred` implementation. 
- Add `where M: Send + 'static` and `M::Result: Send` constraints to the default `Handler::handle_preferred` implementation to reflect runtime requirements. 
- Simplify `ServiceAddress::call` by constructing the envelope unconditionally with `Envelope::new_with_result_channel(message, Some(sender))` and removing the redundant `if M::IS_PERFERRED` branch. 

### Testing

- Ran the crate test suite with `cargo test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb4f446cc832b88e2c23e6a5ca53d)