### PR TITLE
Support value-keyed topics for pub/sub and route waiters by topic value

### DIFF
--- a/actor/examples/topic.rs
+++ b/actor/examples/topic.rs
@@ -4,7 +4,8 @@ use serviceless::{Context, Handler, RoutedTopic, Service, ServiceAddress, Topic,
 #[derive(Clone)]
 pub struct UserReady(pub String);
 
-pub struct UserReadyTopic;
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UserReadyTopic(pub String);
 
 impl Topic for UserReadyTopic {
     type Item = UserReady;
@@ -35,12 +36,15 @@ impl serviceless::Message for DoWork {
 #[async_trait]
 impl Handler<DoWork> for MyService {
     async fn handle(&mut self, _message: DoWork, ctx: &mut Context<Self, Self::Stream>) {
-        let _ = ctx.publish::<UserReadyTopic>(UserReady("done".to_string()));
+        let _ = ctx.publish::<UserReadyTopic>(
+            UserReadyTopic("user-42".to_string()),
+            UserReady("done".to_string()),
+        );
     }
 }
 
 async fn demo(addr: ServiceAddress<MyService>) {
-    let fut = addr.subscribe::<UserReadyTopic>();
+    let fut = addr.subscribe::<UserReadyTopic>(UserReadyTopic("user-42".to_string()));
     let _ = addr.send(DoWork);
     let event = fut.await.unwrap();
     assert_eq!(event.0, "done");

--- a/actor/src/context.rs
+++ b/actor/src/context.rs
@@ -54,15 +54,15 @@ where
         }
     }
 
-    /// Publish one item to topic T.
+    /// Publish one item to a specific topic value.
     ///
     /// The actual delivery is still serialized through the service mailbox.
-    pub fn publish<TopicT>(&self, item: TopicT::Item) -> Result<()>
+    pub fn publish<TopicT>(&self, topic: TopicT, item: TopicT::Item) -> Result<()>
     where
         TopicT: Topic + RoutedTopic<S>,
         S: Service,
     {
-        let env = Envelope::<S>::new_publish_topic::<TopicT>(item);
+        let env = Envelope::<S>::new_publish_topic::<TopicT>(topic, item);
 
         self.sender
             .unbounded_send(env)

--- a/actor/src/docs/pubsub.rs
+++ b/actor/src/docs/pubsub.rs
@@ -23,7 +23,8 @@
 //! #[derive(Clone)]
 //! pub struct UserReady(pub String);
 //!
-//! pub struct UserReadyTopic;
+//! #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+//! pub struct UserReadyTopic(pub String);
 //!
 //! impl Topic for UserReadyTopic {
 //!     type Item = UserReady;
@@ -54,7 +55,7 @@
 //! #[async_trait]
 //! impl Handler<DoWork> for MyService {
 //!     async fn handle(&mut self, _message: DoWork, ctx: &mut Context<Self, Self::Stream>) {
-//!         let _ = ctx.publish::<UserReadyTopic>(UserReady("done".into()));
+//!         let _ = ctx.publish::<UserReadyTopic>(UserReadyTopic("user-42".into()), UserReady("done".into()));
 //!     }
 //! }
 //!
@@ -65,7 +66,7 @@
 //!     tokio::spawn(run);
 //!
 //!     // Same enqueue/await pattern as `examples/topic.rs` (ordering vs. publish is discussed above).
-//!     let ready = addr.subscribe::<UserReadyTopic>();
+//!     let ready = addr.subscribe::<UserReadyTopic>(UserReadyTopic("user-42".into()));
 //!     addr.send(DoWork).expect("send work");
 //!     let event = ready.await.expect("event");
 //!     assert_eq!(event.0, "done");
@@ -75,16 +76,18 @@
 //! ## Publishing
 //!
 //! - **Inside the actor** (common): [`crate::Context::publish`] enqueues a publish envelope. When
-//!   it is processed, [`crate::TopicEndpoint::publish`] runs and wakes every waiter registered at
-//!   that moment, then **clears** the waiter list.
+//!   it is processed, [`crate::TopicEndpoint::publish`] runs and wakes every waiter registered for
+//!   that topic value at that moment, then **clears that value's waiter list**.
 //! - Publishing is therefore a **one-shot fan-out**: each `subscribe` waits for **one** future
-//!   publish; after a publish, subscribers must `subscribe` again to receive another item.
+//!   publish on a specific topic value; after a publish, subscribers must `subscribe` again to
+//!   receive another item for that value.
 //!
 //! ## Subscribing
 //!
 //! - **From outside:** [`crate::ServiceAddress::subscribe`] sends a subscribe envelope; when it
-//!   runs, it registers the caller’s one-shot channel on the endpoint. Await the future to obtain
-//!   the next published `Item` (or [`crate::Error::ServiceStoped`] if the actor stops).
+//!   runs, it registers the caller’s one-shot channel on the endpoint for the provided topic value. Await
+//!   the future to obtain the next published `Item` for that value (or
+//!   [`crate::Error::ServiceStoped`] if the actor stops).
 //!
 //! ## Caveats and patterns
 //!

--- a/actor/src/envelop.rs
+++ b/actor/src/envelop.rs
@@ -36,22 +36,22 @@ impl<S> Envelope<S> {
         Self(Box::new(EnvelopWithMessage::new(message, result_channel)))
     }
 
-    /// Register a one-shot subscriber for topic T.
-    pub fn new_subscribe_topic<T>(result_channel: oneshot::Sender<T::Item>) -> Self
+    /// Register a one-shot subscriber for a specific topic value.
+    pub fn new_subscribe_topic<T>(topic: T, result_channel: oneshot::Sender<T::Item>) -> Self
     where
         S: Service + Send,
         T: Topic + RoutedTopic<S>,
     {
-        Self(Box::new(SubscribeTopicEnvelope::<T>::new(result_channel)))
+        Self(Box::new(SubscribeTopicEnvelope::<T>::new(topic, result_channel)))
     }
 
-    /// Publish one item to topic T.
-    pub fn new_publish_topic<T>(item: T::Item) -> Self
+    /// Publish one item to a specific topic value.
+    pub fn new_publish_topic<T>(topic: T, item: T::Item) -> Self
     where
         S: Service + Send,
         T: Topic + RoutedTopic<S>,
     {
-        Self(Box::new(PublishTopicEnvelope::<T>::new(item)))
+        Self(Box::new(PublishTopicEnvelope::<T>::new(topic, item)))
     }
 
     /// Create an Envelope from a boxed EnvelopWithMessage without re-boxing
@@ -142,16 +142,18 @@ pub(crate) struct SubscribeTopicEnvelope<T>
 where
     T: Topic,
 {
-    result_channel: Option<oneshot::Sender<T::Item>>,
+    topic: T,
+    result_channel: oneshot::Sender<T::Item>,
 }
 
 impl<T> SubscribeTopicEnvelope<T>
 where
     T: Topic,
 {
-    pub(crate) fn new(result_channel: oneshot::Sender<T::Item>) -> Self {
+    pub(crate) fn new(topic: T, result_channel: oneshot::Sender<T::Item>) -> Self {
         Self {
-            result_channel: Some(result_channel),
+            topic,
+            result_channel,
         }
     }
 }
@@ -162,10 +164,12 @@ where
     S: Service + Send,
     T: Topic + RoutedTopic<S>,
 {
-    async fn handle(mut self: Box<Self>, svc: &mut S, _ctx: &mut Context<S, S::Stream>) {
-        if let Some(tx) = self.result_channel.take() {
-            T::endpoint(svc).subscribe(tx);
-        }
+    async fn handle(self: Box<Self>, svc: &mut S, _ctx: &mut Context<S, S::Stream>) {
+        let Self {
+            topic,
+            result_channel,
+        } = *self;
+        T::endpoint(svc).subscribe(topic, result_channel);
     }
 }
 
@@ -173,15 +177,16 @@ pub(crate) struct PublishTopicEnvelope<T>
 where
     T: Topic,
 {
-    item: Option<T::Item>,
+    topic: T,
+    item: T::Item,
 }
 
 impl<T> PublishTopicEnvelope<T>
 where
     T: Topic,
 {
-    pub(crate) fn new(item: T::Item) -> Self {
-        Self { item: Some(item) }
+    pub(crate) fn new(topic: T, item: T::Item) -> Self {
+        Self { topic, item }
     }
 }
 
@@ -191,9 +196,8 @@ where
     S: Service + Send,
     T: Topic + RoutedTopic<S>,
 {
-    async fn handle(mut self: Box<Self>, svc: &mut S, _ctx: &mut Context<S, S::Stream>) {
-        if let Some(item) = self.item.take() {
-            T::endpoint(svc).publish(item);
-        }
+    async fn handle(self: Box<Self>, svc: &mut S, _ctx: &mut Context<S, S::Stream>) {
+        let Self { topic, item } = *self;
+        T::endpoint(svc).publish(&topic, item);
     }
 }

--- a/actor/src/service_address.rs
+++ b/actor/src/service_address.rs
@@ -77,15 +77,15 @@ where
         Ok(())
     }
 
-    /// Subscribe once to topic T.
+    /// Subscribe once to a specific topic value.
     ///
     /// One call waits for one future publication.
-    pub async fn subscribe<T>(&self) -> Result<T::Item>
+    pub async fn subscribe<T>(&self, topic: T) -> Result<T::Item>
     where
         T: Topic + RoutedTopic<S>,
     {
         let (sender, receiver) = oneshot::channel::<T::Item>();
-        let env = Envelope::<S>::new_subscribe_topic::<T>(sender);
+        let env = Envelope::<S>::new_subscribe_topic::<T>(topic, sender);
 
         self.sender
             .unbounded_send(env)

--- a/actor/src/topic.rs
+++ b/actor/src/topic.rs
@@ -1,7 +1,8 @@
 use service_channel::oneshot;
+use std::collections::BTreeMap;
 
 /// A typed pub/sub topic.
-pub trait Topic: Send + 'static {
+pub trait Topic: Ord + Clone + Send + 'static {
     type Item: Clone + Send + 'static;
 }
 
@@ -31,7 +32,7 @@ pub struct TopicEndpoint<T>
 where
     T: Topic,
 {
-    waiters: Vec<oneshot::Sender<T::Item>>,
+    waiters: BTreeMap<T, Vec<oneshot::Sender<T::Item>>>,
 }
 
 impl<T> Default for TopicEndpoint<T>
@@ -41,7 +42,7 @@ where
     /// Empty endpoint with no waiters.
     fn default() -> Self {
         Self {
-            waiters: Vec::new(),
+            waiters: BTreeMap::new(),
         }
     }
 }
@@ -51,24 +52,29 @@ where
     T: Topic,
 {
     /// Register one subscriber waiting for the next publication.
-    pub fn subscribe(&mut self, tx: oneshot::Sender<T::Item>) {
-        self.waiters.push(tx);
+    pub fn subscribe(&mut self, topic: T, tx: oneshot::Sender<T::Item>) {
+        self.waiters.entry(topic).or_default().push(tx);
     }
 
     /// Publish once to all current subscribers, then clear them.
     ///
     /// Subscribers that already dropped are silently skipped.
-    pub fn publish(&mut self, item: T::Item) {
-        let waiters = std::mem::take(&mut self.waiters);
+    pub fn publish(&mut self, topic: &T, item: T::Item) {
+        let waiters = self.waiters.remove(topic).unwrap_or_default();
 
         for tx in waiters {
             let _ = tx.send(item.clone());
         }
     }
 
-    /// Number of registered one-shot subscribers waiting for the next publish.
-    pub fn len(&self) -> usize {
+    /// Number of topic values that currently have at least one waiter.
+    pub fn topic_len(&self) -> usize {
         self.waiters.len()
+    }
+
+    /// Number of registered one-shot subscribers waiting for the next publish on `topic`.
+    pub fn len(&self, topic: &T) -> usize {
+        self.waiters.get(topic).map_or(0, Vec::len)
     }
 
     /// Returns `true` when there are no pending subscribers.
@@ -76,10 +82,20 @@ where
         self.waiters.is_empty()
     }
 
+    /// Returns `true` when there are no pending subscribers on `topic`.
+    pub fn is_topic_empty(&self, topic: &T) -> bool {
+        self.waiters.get(topic).map_or(true, Vec::is_empty)
+    }
+
     /// Remove all pending subscribers without publishing.
     ///
     /// Dropped [`oneshot::Sender`]s cause the corresponding receivers to see a closed channel.
     pub fn clear(&mut self) {
         self.waiters.clear();
+    }
+
+    /// Remove all pending subscribers for a specific topic value.
+    pub fn clear_topic(&mut self, topic: &T) {
+        self.waiters.remove(topic);
     }
 }


### PR DESCRIPTION
### Motivation

- Make topics addressable by concrete topic values instead of only by type so subscribers can wait for a specific key/instance of a topic.
- Preserve per-service routing while allowing multiple distinct topic values to coexist for the same topic type.
- Update the examples and docs to demonstrate subscribing/publishing to a specific topic value.

### Description

- Change `Topic` bound to require `Ord + Clone` and `Topic::Item` to remain `Clone`, and store waiters in a `BTreeMap<T, Vec<oneshot::Sender<T::Item>>>` keyed by topic value in `TopicEndpoint`.
- Update APIs to carry a topic value: `Context::publish` now takes `(topic, item)`, `ServiceAddress::subscribe` now takes `topic`, and `Envelope` constructors and envelope types carry the topic through the mailbox.
- Adjust `TopicEndpoint` methods to `subscribe(&mut self, topic, tx)`, `publish(&mut self, &topic, item)`, and add helpers `topic_len`, `len(topic)`, `is_topic_empty(topic)`, and `clear_topic`.
- Update example `examples/topic.rs` and docs `docs/pubsub.rs` to use a value-bearing `UserReadyTopic(pub String)` and call `subscribe`/`publish` with a specific topic instance, and refactor envelope handling to move/unwrap the topic when processed.

### Testing

- Ran `cargo test` and the unit test suite completed successfully.
- Ran `cargo test --examples` which built and ran the examples' tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd416484cc832b8ebcdd2d6b780b6f)