### PR TITLE
test(actor): add integration coverage for core actor behaviors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,9 +16,17 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --workspace

--- a/actor/src/envelop.rs
+++ b/actor/src/envelop.rs
@@ -42,7 +42,10 @@ impl<S> Envelope<S> {
         S: Service + Send,
         T: Topic + RoutedTopic<S>,
     {
-        Self(Box::new(SubscribeTopicEnvelope::<T>::new(topic, result_channel)))
+        Self(Box::new(SubscribeTopicEnvelope::<T>::new(
+            topic,
+            result_channel,
+        )))
     }
 
     /// Publish one item to a specific topic value.

--- a/actor/src/topic.rs
+++ b/actor/src/topic.rs
@@ -84,7 +84,7 @@ where
 
     /// Returns `true` when there are no pending subscribers on `topic`.
     pub fn is_topic_empty(&self, topic: &T) -> bool {
-        self.waiters.get(topic).map_or(true, Vec::is_empty)
+        self.waiters.get(topic).is_none_or(Vec::is_empty)
     }
 
     /// Remove all pending subscribers without publishing.

--- a/actor/tests/actor_tests.rs
+++ b/actor/tests/actor_tests.rs
@@ -1,0 +1,198 @@
+use async_trait::async_trait;
+use serviceless::{
+    Context, EmptyStream, Handler, Message, ReplyHandle, RoutedTopic, Service, Topic, TopicEndpoint,
+};
+
+#[derive(Default)]
+struct TestActor {
+    value: i32,
+    numbers: TopicEndpoint<NumberTopic>,
+    preferred_used: bool,
+}
+
+#[async_trait]
+impl Service for TestActor {
+    type Stream = EmptyStream<Self>;
+}
+
+struct Add(i32);
+impl Message for Add {
+    type Result = i32;
+}
+
+#[async_trait]
+impl Handler<Add> for TestActor {
+    async fn handle(&mut self, msg: Add, _ctx: &mut Context<Self, Self::Stream>) -> i32 {
+        self.value += msg.0;
+        self.value
+    }
+}
+
+struct Get;
+impl Message for Get {
+    type Result = i32;
+}
+
+#[async_trait]
+impl Handler<Get> for TestActor {
+    async fn handle(&mut self, _msg: Get, _ctx: &mut Context<Self, Self::Stream>) -> i32 {
+        self.value
+    }
+}
+
+
+struct PreferredUsed;
+impl Message for PreferredUsed {
+    type Result = bool;
+}
+
+#[async_trait]
+impl Handler<PreferredUsed> for TestActor {
+    async fn handle(&mut self, _msg: PreferredUsed, _ctx: &mut Context<Self, Self::Stream>) -> bool {
+        self.preferred_used
+    }
+}
+
+struct PreferredAdd(i32);
+impl Message for PreferredAdd {
+    const IS_PERFERRED: bool = true;
+    type Result = i32;
+}
+
+#[async_trait]
+impl Handler<PreferredAdd> for TestActor {
+    async fn handle(&mut self, msg: PreferredAdd, _ctx: &mut Context<Self, Self::Stream>) -> i32 {
+        self.value += msg.0;
+        self.value
+    }
+
+    async fn handle_preferred(
+        &mut self,
+        msg: PreferredAdd,
+        _ctx: &mut Context<Self, Self::Stream>,
+        handle: ReplyHandle<PreferredAdd>,
+    ) {
+        self.preferred_used = true;
+        self.value += msg.0;
+        let _ = handle.send(self.value);
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+enum NumberTopic {
+    Even,
+}
+
+impl Topic for NumberTopic {
+    type Item = i32;
+}
+
+impl RoutedTopic<TestActor> for NumberTopic {
+    fn endpoint(service: &mut TestActor) -> &mut TopicEndpoint<Self> {
+        &mut service.numbers
+    }
+}
+
+struct PublishNumber {
+    topic: NumberTopic,
+    value: i32,
+}
+
+impl Message for PublishNumber {
+    type Result = ();
+}
+
+#[async_trait]
+impl Handler<PublishNumber> for TestActor {
+    async fn handle(&mut self, msg: PublishNumber, ctx: &mut Context<Self, Self::Stream>) {
+        let _ = ctx.publish(msg.topic, msg.value);
+    }
+}
+
+#[tokio::test]
+async fn call_and_send_update_actor_state() {
+    let (addr, run) = TestActor::default().start_by_context(Context::new());
+    let runner = tokio::spawn(run);
+
+    let v = addr.call(Add(2)).await.expect("call add should succeed");
+    assert_eq!(v, 2);
+
+    addr.send(Add(3)).expect("send add should succeed");
+    let final_value = addr.call(Get).await.expect("get should succeed");
+    assert_eq!(final_value, 5);
+
+    addr.close_service();
+    runner.await.expect("service task should finish");
+}
+
+#[tokio::test]
+async fn preferred_handler_path_is_used_for_preferred_messages() {
+    let (addr, run) = TestActor::default().start_by_context(Context::new());
+    let runner = tokio::spawn(run);
+
+    let v = addr
+        .call(PreferredAdd(7))
+        .await
+        .expect("preferred call should succeed");
+    assert_eq!(v, 7);
+
+    let state = addr.call(Get).await.expect("get should succeed");
+    assert_eq!(state, 7);
+
+    let used = addr
+        .call(PreferredUsed)
+        .await
+        .expect("preferred status should be readable");
+    assert!(used);
+
+    addr.close_service();
+    runner.await.expect("service task should finish");
+}
+
+#[tokio::test]
+async fn into_address_forwards_messages_to_service() {
+    let (addr, run) = TestActor::default().start_by_context(Context::new());
+    let runner = tokio::spawn(run);
+
+    let (typed_addr, forward) = addr.clone().into_address::<Add>();
+    let forwarder = tokio::spawn(forward);
+
+    let v = typed_addr.call(Add(4)).await.expect("typed call should succeed");
+    assert_eq!(v, 4);
+
+    let state = addr.call(Get).await.expect("get should succeed");
+    assert_eq!(state, 4);
+
+    drop(typed_addr);
+    addr.close_service();
+
+    forwarder.await.expect("forwarder task should finish");
+    runner.await.expect("service task should finish");
+}
+
+#[tokio::test]
+async fn subscribe_receives_published_topic_item() {
+    let (addr, run) = TestActor::default().start_by_context(Context::new());
+    let runner = tokio::spawn(run);
+
+    let sub_addr = addr.clone();
+    let subscriber = tokio::spawn(async move {
+        sub_addr
+            .subscribe(NumberTopic::Even)
+            .await
+            .expect("subscribe should receive published value")
+    });
+
+    tokio::task::yield_now().await;
+    addr.send(PublishNumber {
+        topic: NumberTopic::Even,
+        value: 42,
+    })
+    .expect("publish message should enqueue");
+
+    let published = subscriber.await.expect("subscriber task should finish");
+    assert_eq!(published, 42);
+
+    addr.close_service();
+    runner.await.expect("service task should finish");
+}

--- a/actor/tests/actor_tests.rs
+++ b/actor/tests/actor_tests.rs
@@ -40,7 +40,6 @@ impl Handler<Get> for TestActor {
     }
 }
 
-
 struct PreferredUsed;
 impl Message for PreferredUsed {
     type Result = bool;
@@ -48,7 +47,11 @@ impl Message for PreferredUsed {
 
 #[async_trait]
 impl Handler<PreferredUsed> for TestActor {
-    async fn handle(&mut self, _msg: PreferredUsed, _ctx: &mut Context<Self, Self::Stream>) -> bool {
+    async fn handle(
+        &mut self,
+        _msg: PreferredUsed,
+        _ctx: &mut Context<Self, Self::Stream>,
+    ) -> bool {
         self.preferred_used
     }
 }
@@ -157,7 +160,10 @@ async fn into_address_forwards_messages_to_service() {
     let (typed_addr, forward) = addr.clone().into_address::<Add>();
     let forwarder = tokio::spawn(forward);
 
-    let v = typed_addr.call(Add(4)).await.expect("typed call should succeed");
+    let v = typed_addr
+        .call(Add(4))
+        .await
+        .expect("typed call should succeed");
     assert_eq!(v, 4);
 
     let state = addr.call(Get).await.expect("get should succeed");

--- a/channel/src/mpsc.rs
+++ b/channel/src/mpsc.rs
@@ -767,7 +767,6 @@ mod tests {
     use alloc::format;
     use alloc::string::{String, ToString};
     use alloc::vec;
-    use alloc::vec::Vec;
 
     #[test]
     fn test_basic_send_recv() {
@@ -798,9 +797,7 @@ mod tests {
         tx1.unbounded_send(1).unwrap();
         tx2.unbounded_send(2).unwrap();
 
-        let mut received = Vec::new();
-        received.push(rx.try_recv().unwrap());
-        received.push(rx.try_recv().unwrap());
+        let mut received = vec![rx.try_recv().unwrap(), rx.try_recv().unwrap()];
         received.sort();
         assert_eq!(received, vec![1, 2]);
     }
@@ -1042,9 +1039,7 @@ mod tests {
         tx1.unbounded_send(1).unwrap();
         tx2.unbounded_send(2).unwrap();
 
-        let mut received = Vec::new();
-        received.push(rx.try_recv().unwrap());
-        received.push(rx.try_recv().unwrap());
+        let mut received = vec![rx.try_recv().unwrap(), rx.try_recv().unwrap()];
         received.sort();
         assert_eq!(received, vec![1, 2]);
     }


### PR DESCRIPTION
### Motivation
- Improve test coverage for the actor crate by exercising core mailbox/message/topic flows and the preferred message path.
- Verify `ServiceAddress::into_address` forwarding and topic subscribe/publish semantics to prevent regressions in message routing.

### Description
- Add `actor/tests/actor_tests.rs` which defines a `TestActor` and message/topic fixtures used across tests.
- Implement handlers for `Add`, `Get`, `PreferredAdd`, `PreferredUsed`, and `PublishNumber`, plus a `NumberTopic` with `TopicEndpoint` usage.
- Add tests covering `call` + `send` ordering, the `IS_PERFERRED` preferred handler path (and readback via `PreferredUsed`), `into_address` forwarding from `Address<M>` to the service mailbox, and one-shot topic subscribe/publish delivery.

### Testing
- Ran `cargo test -p serviceless`, and the new integration tests all passed (4 integration tests) and crate doc-tests compiled and passed (13 doc-tests); overall test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd47323038832b8adaadbfda8b0c1d)